### PR TITLE
FIX mismatching doctype

### DIFF
--- a/star_gen.html
+++ b/star_gen.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<html lang="en">
 	<head>
 		<title>Star System Generator</title>
 		<meta charset="utf-8">


### PR DESCRIPTION
The document type is both declared as HTML5 (with the `<!doctype html>` magic comment) and as XHTML (with the `xmlns="http://www.w3.org/1999/xhtml"` attribute on the `<html>` element).

On most browsers, this is fine, but it causes browsers based on webkit-gtk to prioritize XHTML, and then the page is not XHTML valid and renders only partially, with errors.

![parse-error](https://github.com/user-attachments/assets/b4eb5f04-a657-4ec6-a1b7-e5e398d4bcaf)

I realized this because I use a webkit-gtk based browser, but it's possible it affects webkit browsers as well, like Safari.

Anyway, the fix is easy : XHTML is a thing of the past. :)